### PR TITLE
Strings and Boxed types should be compared using "equals()"

### DIFF
--- a/src/main/java/org/apache/sling/auth/core/impl/SlingAuthenticator.java
+++ b/src/main/java/org/apache/sling/auth/core/impl/SlingAuthenticator.java
@@ -1425,7 +1425,7 @@ public class SlingAuthenticator implements Authenticator,
         String currentSudo = getSudoCookieValue(req);
 
         // set the (new) impersonation
-        final boolean setCookie = sudo != currentSudo;
+        final boolean setCookie = !sudo.equals(currentSudo);
         if (setCookie) {
             if (sudo == null) {
                 // Parameter set to "-" to clear impersonation, which was


### PR DESCRIPTION
This fixes 1 Sonarqube violation of rule S4973:
https://rules.sonarsource.com/java/RSPEC-4973

Sonarcloud violation URL:
https://sonarcloud.io/organizations/apache/issues?languages=java&open=AWogePnQ9zLXaOU8uV59&resolved=false&rules=squid%3AS4973&types=BUG

Jira Ticket:
https://issues.apache.org/jira/browse/SLING-8825