### PR TITLE
custom authentication handling incase credentials are passed through internal micsroservices within headers

### DIFF
--- a/src/main/java/org/apache/sling/auth/core/impl/SlingAuthenticator.java
+++ b/src/main/java/org/apache/sling/auth/core/impl/SlingAuthenticator.java
@@ -134,6 +134,12 @@ public class SlingAuthenticator implements Authenticator,
 
     @Property(cardinality = 2147483647)
     private static final String PAR_AUTH_REQ = AuthConstants.AUTH_REQUIREMENTS;
+    
+    @Property()
+    private static final String CUSTOM_AUTH_USER = "X-Auth-User";
+
+    @Property()
+    private static final String CUSTOM_AUTH_TOKEN = "X-Auth-Token";
 
     @Property()
     private static final String PAR_ANONYMOUS_USER = "sling.auth.anonymous.user";
@@ -759,6 +765,13 @@ public class SlingAuthenticator implements Authenticator,
                 authInfo.put(AUTH_INFO_PROP_FEEDBACK_HANDLER, httpBasicHandler);
                 return authInfo;
             }
+        }
+        // handler for custom authentication from headers...
+
+        if(null != request.getHeader(CUSTOM_AUTH_USER) && null != request.getHeader(CUSTOM_AUTH_TOKEN)){
+            final AuthenticationInfo authInfo = new AuthenticationInfo(HttpServletRequest.BASIC_AUTH, request.getHeader(CUSTOM_AUTH_TOKEN).toString(),
+                    request.getHeader(CUSTOM_AUTH_TOKEN).toCharArray());
+            return authInfo;
         }
 
         // no handler found for the request ....


### PR DESCRIPTION
Hi Team,

Currently Basic Auth is supported in case of external request, I found, we should also add custom authentication handler, whereby, if one micro service is providing credential in headers, there should be a way to validate that request as well.

Please let me know, in case more clarification is required.
On a side note, i wanted to have commit access as well on this repository, let me know, in case there are any  path, i can follow.