### PR TITLE
Adding requestURL to the log for better traceablility

### DIFF
--- a/src/main/java/org/apache/sling/auth/core/impl/AuthenticationHandlerHolder.java
+++ b/src/main/java/org/apache/sling/auth/core/impl/AuthenticationHandlerHolder.java
@@ -78,7 +78,7 @@ final class AuthenticationHandlerHolder extends
     @Override
     public AuthenticationInfo doExtractCredentials(HttpServletRequest request,
             HttpServletResponse response) {
-        logger.debug("doExtractCredentials: Using AuthenticationHandler class {} to extract credentials", handler);
+        this.logDebugMessage("doExtractCredentials: Using AuthenticationHandler class {} to extract credentials for request {} {}", request);
         return handler.extractCredentials(request, response);
     }
 
@@ -88,7 +88,7 @@ final class AuthenticationHandlerHolder extends
 
         // call handler if ok by its authentication type
         if (doesRequestCredentials(request)) {
-            logger.debug("doRequestCredentials: Using AuthenticationHandler class {} to request credentials", handler);
+            this.logDebugMessage("doRequestCredentials: Using AuthenticationHandler class {} to request credentials for request {} {}", request);
             return handler.requestCredentials(request, response);
         }
 
@@ -99,7 +99,7 @@ final class AuthenticationHandlerHolder extends
     @Override
     public void doDropCredentials(HttpServletRequest request,
             HttpServletResponse response) throws IOException {
-        logger.debug("doDropCredentials: Using AuthenticationHandler class {} to drop credentials", handler);
+        this.logDebugMessage("doDropCredentials: Using AuthenticationHandler class {} to drop credentials for request {} {}", request);
         handler.dropCredentials(request, response);
     }
 
@@ -164,5 +164,11 @@ final class AuthenticationHandlerHolder extends
 
         final String requestLogin = AuthUtil.getAttributeOrParameter(request, REQUEST_LOGIN_PARAMETER, null);
         return requestLogin == null || authType.equals(requestLogin);
+    }
+
+    private void logDebugMessage(String message, HttpServletRequest request) {
+        if (logger.isDebugEnabled()) {
+            logger.debug(message, handler, request.getMethod() ,request.getRequestURL());
+        }
     }
 }

--- a/src/main/java/org/apache/sling/auth/core/impl/AuthenticationHandlerHolder.java
+++ b/src/main/java/org/apache/sling/auth/core/impl/AuthenticationHandlerHolder.java
@@ -78,7 +78,7 @@ final class AuthenticationHandlerHolder extends
     @Override
     public AuthenticationInfo doExtractCredentials(HttpServletRequest request,
             HttpServletResponse response) {
-        this.logDebugMessage("doExtractCredentials: Using AuthenticationHandler class {} to extract credentials for request {} {}", request);
+        this.logDebugMessage("doExtractCredentials", request);
         return handler.extractCredentials(request, response);
     }
 
@@ -88,7 +88,7 @@ final class AuthenticationHandlerHolder extends
 
         // call handler if ok by its authentication type
         if (doesRequestCredentials(request)) {
-            this.logDebugMessage("doRequestCredentials: Using AuthenticationHandler class {} to request credentials for request {} {}", request);
+            this.logDebugMessage("doRequestCredentials", request);
             return handler.requestCredentials(request, response);
         }
 
@@ -99,7 +99,7 @@ final class AuthenticationHandlerHolder extends
     @Override
     public void doDropCredentials(HttpServletRequest request,
             HttpServletResponse response) throws IOException {
-        this.logDebugMessage("doDropCredentials: Using AuthenticationHandler class {} to drop credentials for request {} {}", request);
+        this.logDebugMessage("doDropCredentials", request);
         handler.dropCredentials(request, response);
     }
 
@@ -166,7 +166,8 @@ final class AuthenticationHandlerHolder extends
         return requestLogin == null || authType.equals(requestLogin);
     }
 
-    private void logDebugMessage(String message, HttpServletRequest request) {
+    private void logDebugMessage(String functionName, HttpServletRequest request) {
+        String message = functionName + ": Using AuthenticationHandler class {} to request credentials for request {} {}";
         if (logger.isDebugEnabled()) {
             logger.debug(message, handler, request.getMethod() ,request.getRequestURL());
         }

--- a/src/main/java/org/apache/sling/auth/core/impl/AuthenticationHandlerHolder.java
+++ b/src/main/java/org/apache/sling/auth/core/impl/AuthenticationHandlerHolder.java
@@ -167,8 +167,8 @@ final class AuthenticationHandlerHolder extends
     }
 
     private void logDebugMessage(String functionName, HttpServletRequest request) {
-        String message = functionName + ": Using AuthenticationHandler class {} to request credentials for request {} {}";
         if (logger.isDebugEnabled()) {
+            String message = functionName + ": Using AuthenticationHandler class {} to request credentials for request {} {}";
             logger.debug(message, handler, request.getMethod() ,request.getRequestURL());
         }
     }

--- a/src/test/java/org/apache/sling/auth/core/impl/SlingAuthenticatorOsgiTest.java
+++ b/src/test/java/org/apache/sling/auth/core/impl/SlingAuthenticatorOsgiTest.java
@@ -105,6 +105,7 @@ public class SlingAuthenticatorOsgiTest {
     @Test
     public void testHandleSecurity() throws IOException {
         HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getRequestURL()).thenReturn(new StringBuffer("/"));
         when(req.getServletPath()).thenReturn("/");
         when(req.getServerName()).thenReturn("localhost");
         when(req.getServerPort()).thenReturn(80);
@@ -131,6 +132,7 @@ public class SlingAuthenticatorOsgiTest {
                     // provide test authInfo 
                     AuthenticationInfo authInfo = new AuthenticationInfo("testing", "admin", "admin".toCharArray());
                     authInfo.put(AuthConstants.AUTH_INFO_LOGIN, Boolean.TRUE);
+                    when(req.getRequestURL()).thenReturn(new StringBuffer("/test"));
                     when(testAuthHandler.extractCredentials(req, resp)).thenReturn(authInfo);
                 },
                 () -> testEventHandler.collectedEvents(AuthConstants.TOPIC_LOGIN),
@@ -147,6 +149,7 @@ public class SlingAuthenticatorOsgiTest {
                 (req, resp) -> {
                     // provide invalid test authInfo 
                     AuthenticationInfo authInfo = new AuthenticationInfo("testing", "invalid", "invalid".toCharArray());
+                    when(req.getRequestURL()).thenReturn(new StringBuffer("/testing"));
                     when(testAuthHandler.extractCredentials(req, resp)).thenReturn(authInfo);
                     // throw exception to trigger FailedLogin event
                     try {


### PR DESCRIPTION
Ability to log the requestURL that the sling authentication engine is currently validating.

Note that since the authentication occurs before the main servlet the thread ID is not set to the request URL and for that reason you cannot see the request URL in the logs during the authentication process. 