### PR TITLE
SLING-12885 provide a non-deprecated FAILURE_REASON_CODES enum

### DIFF
--- a/src/main/java/org/apache/sling/auth/core/impl/FailureCodesMapper.java
+++ b/src/main/java/org/apache/sling/auth/core/impl/FailureCodesMapper.java
@@ -24,8 +24,8 @@ import javax.security.auth.login.AccountNotFoundException;
 import javax.security.auth.login.CredentialExpiredException;
 
 import org.apache.sling.api.resource.LoginException;
-import org.apache.sling.auth.core.spi.AuthenticationHandler.FAILURE_REASON_CODES;
 import org.apache.sling.auth.core.spi.AuthenticationInfo;
+import org.apache.sling.auth.core.spi.JakartaAuthenticationHandler.FAILURE_REASON_CODES;
 import org.jetbrains.annotations.NotNull;
 
 public final class FailureCodesMapper {
@@ -46,8 +46,8 @@ public final class FailureCodesMapper {
                 // force failure attribute to be set so handlers can
                 // react to this special circumstance
                 Object creds = authInfo.get("user.jcr.credentials");
-                if (creds instanceof SimpleCredentials
-                        && ((SimpleCredentials) creds).getAttribute("PasswordHistoryException") != null) {
+                if (creds instanceof SimpleCredentials simpleCreds
+                        && simpleCreds.getAttribute("PasswordHistoryException") != null) {
                     code = FAILURE_REASON_CODES.PASSWORD_EXPIRED_AND_NEW_PASSWORD_IN_HISTORY;
                 } else {
                     code = FAILURE_REASON_CODES.PASSWORD_EXPIRED;

--- a/src/main/java/org/apache/sling/auth/core/spi/AuthenticationHandler.java
+++ b/src/main/java/org/apache/sling/auth/core/spi/AuthenticationHandler.java
@@ -122,10 +122,13 @@ public interface AuthenticationHandler {
      *     <li><code>expired_token</code>: the token credentials used have expired</li>
      * </ul>
      * @since 1.1.0
+     * @deprecated use {@link JakartaAuthenticationHandler.FAILURE_REASON_CODES} instead
      */
     // When adding a new field to the enum bnd will require a minor version bump
     // That's unfortunately too much for an SPI package and should really have no impact
     // on implementors since the enum values are not exposed from any public API
+    // NOTE: a mirror of this enum is in JakartaAuthenticationHandler so keep these
+    //   two copies in sync
     @BaselineIgnore("1.2.3")
     enum FAILURE_REASON_CODES {
         /** Login is invald */

--- a/src/main/java/org/apache/sling/auth/core/spi/JakartaAuthenticationHandler.java
+++ b/src/main/java/org/apache/sling/auth/core/spi/JakartaAuthenticationHandler.java
@@ -20,6 +20,7 @@ package org.apache.sling.auth.core.spi;
 
 import java.io.IOException;
 
+import aQute.bnd.annotation.baseline.BaselineIgnore;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.osgi.annotation.versioning.ConsumerType;
@@ -105,6 +106,46 @@ public interface JakartaAuthenticationHandler {
      * @see #extractCredentials(HttpServletRequest, HttpServletResponse)
      */
     static final String FAILURE_REASON_CODE = "j_reason_code";
+
+    /**
+     * This enum indicates the supported detailed login failure reason codes:
+     * <ul>
+     *     <li><code>invalid_login</code>: indicates username/password mismatch.</li>
+     *     <li><code>password_expired</code>: indicates password has expired or was never set and
+     *     change initial password is enabled</li>
+     *     <li><code>account_locked</code>: the account was disabled or locked</li>
+     *     <li><code>account_not_found</code>: the account was not found (not the same as username password mismatch)</li>
+     *     <li><code>expired_token</code>: the token credentials used have expired</li>
+     * </ul>
+     * @since 1.1.0
+     */
+    // When adding a new field to the enum bnd will require a minor version bump
+    // That's unfortunately too much for an SPI package and should really have no impact
+    // on implementors since the enum values are not exposed from any public API
+    // NOTE: a mirror of this enum is in the deprecated AuthenticationHandler so keep these
+    //   two copies in sync
+    @BaselineIgnore("1.2.3")
+    enum FAILURE_REASON_CODES {
+        /** Login is invald */
+        INVALID_LOGIN,
+        /** Password has expired */
+        PASSWORD_EXPIRED,
+        /** Password has expired and a new password is in history */
+        PASSWORD_EXPIRED_AND_NEW_PASSWORD_IN_HISTORY,
+        /** Unknown reason */
+        UNKNOWN,
+        /** Account is locked or disabled */
+        ACCOUNT_LOCKED,
+        /** Account was not found */
+        ACCOUNT_NOT_FOUND,
+        /** The token credentials used have expired */
+        EXPIRED_TOKEN;
+
+        @Override
+        public String toString() {
+            return super.toString().toLowerCase();
+        }
+    }
 
     /**
      * Extracts credential data from the request if at all contained.

--- a/src/main/java/org/apache/sling/auth/core/spi/package-info.java
+++ b/src/main/java/org/apache/sling/auth/core/spi/package-info.java
@@ -26,7 +26,7 @@
  * being an abstract base implementation from which concrete
  * implementations may inherit.
  *
- * @version 1.3.0
+ * @version 1.4.0
  */
-@org.osgi.annotation.versioning.Version("1.3.0")
+@org.osgi.annotation.versioning.Version("1.4.0")
 package org.apache.sling.auth.core.spi;

--- a/src/test/java/org/apache/sling/auth/core/impl/FailureCodesMapperTest.java
+++ b/src/test/java/org/apache/sling/auth/core/impl/FailureCodesMapperTest.java
@@ -24,8 +24,8 @@ import javax.security.auth.login.AccountNotFoundException;
 import javax.security.auth.login.CredentialExpiredException;
 
 import org.apache.sling.api.resource.LoginException;
-import org.apache.sling.auth.core.spi.AuthenticationHandler.FAILURE_REASON_CODES;
 import org.apache.sling.auth.core.spi.AuthenticationInfo;
+import org.apache.sling.auth.core.spi.JakartaAuthenticationHandler.FAILURE_REASON_CODES;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;


### PR DESCRIPTION
The AuthenticationHandler.FAILURE_REASON_CODES enum is marked as deprecated but the enum name is still used as the value of the "j_reason_code" request parameter for forms auth.

Any custom login page can not translate the "j_reason_code" string back to an enum for ease of use without ignoring or suppressing warnings about usage of the deprecated enum type.

Suggest creating a mirror enum in the JakartaAuthenticationHandler class so the info is not deprecated

A new configuration field can be used to continue using the deprecated enum for backward compatiblity if needed.