### PR TITLE
SLING-13025 Evaluate "resource" as fallback to "sling.auth.redirect"

### DIFF
--- a/src/main/java/org/apache/sling/auth/core/AuthUtil.java
+++ b/src/main/java/org/apache/sling/auth/core/AuthUtil.java
@@ -37,6 +37,7 @@ import org.apache.sling.api.auth.Authenticator;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.auth.core.spi.JakartaAuthenticationHandler;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -183,6 +184,7 @@ public final class AuthUtil {
      * @return The non-empty redirection target or
      *         <code>defaultLoginResource</code>.
      * @since 1.6.0
+     * @see AuthUtil#getMappedLoginResourcePath(HttpServletRequest, String)
      */
     public static String getLoginResource(final HttpServletRequest request, String defaultLoginResource) {
         return getAttributeOrParameter(request, Authenticator.LOGIN_RESOURCE, defaultLoginResource);
@@ -201,11 +203,47 @@ public final class AuthUtil {
      * @return The non-empty redirection target or
      *         <code>defaultLoginResource</code>.
      * @deprecated Use {@link #getLoginResource(HttpServletRequest, String)}
+     * @see #getMappedLoginResourcePath(javax.servlet.http.HttpServletRequest, String)
      */
     @Deprecated
     public static String getLoginResource(
             final javax.servlet.http.HttpServletRequest request, String defaultLoginResource) {
         return getAttributeOrParameter(request, Authenticator.LOGIN_RESOURCE, defaultLoginResource);
+    }
+
+    /**
+     * Returns the mapped resource path (to redirect to after a successful authentication).
+     * It still needs to be validated by the caller.
+     * Use this method to issue a redirect instead of {@link #getLoginResource(HttpServletRequest, String)} to correctly consider resource resolver mapping.
+     * @return the mapped path of the resource target or {@code null} if non is given in the request
+     * @since 1.7.0 (Bundle Version 2.1.0)
+     */
+    public static @Nullable String getMappedLoginResourcePath(
+            final HttpServletRequest request, String defaultLoginResource) {
+        String resourcePath = getLoginResource(request, defaultLoginResource);
+        if (resourcePath == null) {
+            return null;
+        }
+        return getResourceResolver(request).map(request, resourcePath);
+    }
+
+    /**
+     * Returns the mapped resource path (to redirect to after a successful authentication).
+     * It still needs to be validated by the caller.
+     * Use this method to issue a redirect instead of {@link #getLoginResource(javax.servlet.http.HttpServletRequest, String)} to correctly consider resource resolver mapping.
+     * @return the mapped path of the resource target or {@code null} if non is given in the request
+     *
+     * @deprecated Use {@link #getMappedLoginResourcePath(HttpServletRequest, String)}
+     * @since 1.7.0 (Bundle Version 2.1.0)
+     */
+    @Deprecated
+    public static @Nullable String getMappedLoginResourcePath(
+            final javax.servlet.http.HttpServletRequest request, String defaultLoginResource) {
+        String resourcePath = getLoginResource(request, defaultLoginResource);
+        if (resourcePath == null) {
+            return null;
+        }
+        return getResourceResolver(request).map(request, resourcePath);
     }
 
     /**

--- a/src/main/java/org/apache/sling/auth/core/impl/LoginServlet.java
+++ b/src/main/java/org/apache/sling/auth/core/impl/LoginServlet.java
@@ -77,7 +77,7 @@ public class LoginServlet extends SlingAllMethodsServlet {
         // through the login servlet), redirect to root now assuming we are
         // authenticated.
         if (request.getAuthType() != null) {
-            final String resourcePath = AuthUtil.getLoginResource(request, null);
+            final String resourcePath = AuthUtil.getMappedLoginResourcePath(request, null);
             if (isSelf(resourcePath)) {
                 String redirectTarget = request.getContextPath() + "/";
                 log.warn("doGet: Redirecting to {} to prevent login loop for resource", redirectTarget);

--- a/src/main/java/org/apache/sling/auth/core/impl/SlingAuthenticator.java
+++ b/src/main/java/org/apache/sling/auth/core/impl/SlingAuthenticator.java
@@ -1462,6 +1462,7 @@ public class SlingAuthenticator implements Authenticator, AuthenticationSupport,
 
         // find the redirect target from the resource attribute or parameter
         // falling back to the request context path (or /) if not set or invalid
+        // TODO: apply mapping, but no resource resolver at hand, use service resource resolver?
         String target = AuthUtil.getLoginResource(request, request.getContextPath());
         if (!AuthUtil.isRedirectValid(request, target)) {
             log.warn("redirectAfterLogout: Desired redirect target is invalid; redirecting to '/'");

--- a/src/main/java/org/apache/sling/auth/core/package-info.java
+++ b/src/main/java/org/apache/sling/auth/core/package-info.java
@@ -22,7 +22,7 @@
  * of utility functions in the {@link org.apache.sling.auth.core.AuthUtil}
  * class.
  *
- * @version 1.6.0
+ * @version 1.7.0
  */
-@org.osgi.annotation.versioning.Version("1.6.0")
+@org.osgi.annotation.versioning.Version("1.7.0")
 package org.apache.sling.auth.core;

--- a/src/main/java/org/apache/sling/auth/core/spi/DefaultAuthenticationFeedbackHandler.java
+++ b/src/main/java/org/apache/sling/auth/core/spi/DefaultAuthenticationFeedbackHandler.java
@@ -37,8 +37,9 @@ public class DefaultAuthenticationFeedbackHandler implements AuthenticationFeedb
      * authentication and <code>true</code> if the request has been redirected.
      * <p>
      * This method checks {@link AuthenticationSupport#REDIRECT_PARAMETER}
-     * request parameter for the redirect target. This parameter is handled
-     * as follows:
+     * request parameter for the redirect target. If that is not set, it falls back
+     * to check for {@link AuthUtil#getMappedLoginResourcePath(HttpServletRequest, String)}.
+     * The parameter is handled as follows:
      * <ul>
      * <li>If the parameter does not exist, the method does not redirect and
      * <code>false</code> is returned.</li>
@@ -101,7 +102,10 @@ public class DefaultAuthenticationFeedbackHandler implements AuthenticationFeedb
     private static String getValidatedRedirectTarget(final HttpServletRequest request) {
         String redirect = request.getParameter(AuthenticationSupport.REDIRECT_PARAMETER);
         if (redirect == null) {
-            return null;
+            redirect = AuthUtil.getMappedLoginResourcePath(request, null);
+            if (redirect == null) {
+                return null;
+            }
         }
 
         // redirect to the same path

--- a/src/main/java/org/apache/sling/auth/core/spi/DefaultJakartaAuthenticationFeedbackHandler.java
+++ b/src/main/java/org/apache/sling/auth/core/spi/DefaultJakartaAuthenticationFeedbackHandler.java
@@ -36,8 +36,10 @@ public class DefaultJakartaAuthenticationFeedbackHandler implements JakartaAuthe
      * authentication and <code>true</code> if the request has been redirected.
      * <p>
      * This method checks {@link AuthenticationSupport#REDIRECT_PARAMETER}
-     * request parameter for the redirect target. This parameter is handled
-     * as follows:
+     * request parameter for the redirect target. If that is not set, it falls back
+     * to check for {@link AuthUtil#getMappedLoginResourcePath(HttpServletRequest, String)}.
+     *
+     * The parameter is handled as follows:
      * <ul>
      * <li>If the parameter does not exist, the method does not redirect and
      * <code>false</code> is returned.</li>
@@ -100,7 +102,10 @@ public class DefaultJakartaAuthenticationFeedbackHandler implements JakartaAuthe
     private static String getValidatedRedirectTarget(final HttpServletRequest request) {
         String redirect = request.getParameter(AuthenticationSupport.REDIRECT_PARAMETER);
         if (redirect == null) {
-            return null;
+            redirect = AuthUtil.getMappedLoginResourcePath(request, null);
+            if (redirect == null) {
+                return null;
+            }
         }
 
         // redirect to the same path


### PR DESCRIPTION
In most cases the "resource" is anyhow set (to correctly deal with failed authentications to determine the login path) and is used as redirect target for successful authentications as well.